### PR TITLE
Added option to return original response

### DIFF
--- a/src/Teepluss/Hmvc/Hmvc.php
+++ b/src/Teepluss/Hmvc/Hmvc.php
@@ -99,7 +99,11 @@ class Hmvc {
 
             // Dispatch request.
             $dispatch = $this->router->dispatch($request);
-
+            
+            if (array_key_exists ("getOriginalResponse", $parameters) && $parameters ["getOriginalResponse"]) 
+            {
+                return $dispatch;
+            }
             if (method_exists($dispatch, 'getOriginalContent'))
             {
                 $response = $dispatch->getOriginalContent();


### PR DESCRIPTION
Sometimes is needed to return the original Response object returned by laravel. Adding a parameter named "getOriginalResponse" in the parameters will return the original object.
