### PR TITLE
Added parameter $returnOriginalResponse 

### DIFF
--- a/src/Teepluss/Hmvc/Hmvc.php
+++ b/src/Teepluss/Hmvc/Hmvc.php
@@ -74,7 +74,7 @@ class Hmvc {
      * @param  array  $parameters
      * @return mixed
      */
-    public function invoke($uri, $method, $parameters = array())
+    public function invoke($uri, $method, $parameters = array(), $returnOriginalResponse)
     {
         // Request URI.
         $uri = '/'.ltrim($uri, '/');
@@ -100,7 +100,7 @@ class Hmvc {
             // Dispatch request.
             $dispatch = $this->router->dispatch($request);
             
-            if (array_key_exists ("getOriginalResponse", $parameters) && $parameters ["getOriginalResponse"]) 
+            if ($returnOriginalResponse) 
             {
                 return $dispatch;
             }
@@ -203,7 +203,7 @@ class Hmvc {
      *
      * @return mixed
      */
-    public function __call($method, $parameters = array())
+    public function __call($method, $parameters = array(), $returnOriginalResponse = false)
     {
         if (in_array($method, array('get', 'patch', 'post', 'put', 'delete')))
         {
@@ -217,7 +217,7 @@ class Hmvc {
                 return $this->invokeRemote($uri, $method, $parameters);
             }
 
-            return $this->invoke($uri, $method, $parameters);
+            return $this->invoke($uri, $method, $parameters, $returnOriginalResponse);
         }
     }
 

--- a/src/Teepluss/Hmvc/Hmvc.php
+++ b/src/Teepluss/Hmvc/Hmvc.php
@@ -74,7 +74,7 @@ class Hmvc {
      * @param  array  $parameters
      * @return mixed
      */
-    public function invoke($uri, $method, $parameters = array(), $returnOriginalResponse)
+    public function invoke($uri, $method, $parameters = array(), $returnOriginalResponse = false)
     {
         // Request URI.
         $uri = '/'.ltrim($uri, '/');
@@ -203,7 +203,7 @@ class Hmvc {
      *
      * @return mixed
      */
-    public function __call($method, $parameters = array(), $returnOriginalResponse = false)
+    public function __call($method, $parameters = array())
     {
         if (in_array($method, array('get', 'patch', 'post', 'put', 'delete')))
         {
@@ -217,7 +217,7 @@ class Hmvc {
                 return $this->invokeRemote($uri, $method, $parameters);
             }
 
-            return $this->invoke($uri, $method, $parameters, $returnOriginalResponse);
+            return $this->invoke($uri, $method, $parameters, false);
         }
     }
 

--- a/src/Teepluss/Hmvc/Hmvc.php
+++ b/src/Teepluss/Hmvc/Hmvc.php
@@ -99,7 +99,11 @@ class Hmvc {
 
             // Dispatch request.
             $dispatch = $this->router->dispatch($request);
-
+            
+            if (array_key_exists ("getOriginalResponse", $parameters) && $parameters ["getOriginalResponse"]) 
+            {
+                return $dispatch;
+            }
             if (method_exists($dispatch, 'getOriginalContent'))
             {
                 $response = $dispatch->getOriginalContent();


### PR DESCRIPTION
Sometimes is needed to return the original Response object returned by laravel. Adding a parameter named "getOriginalResponse" in the parameters will return the original object.